### PR TITLE
Adjust websocket matchmaking route

### DIFF
--- a/src/app/domain/match/__init__.py
+++ b/src/app/domain/match/__init__.py
@@ -2,4 +2,4 @@ from fastapi import APIRouter
 from .router import match_controller
 
 router = APIRouter()
-router.include_router(match_controller.router, prefix="/match", tags=["match"])
+router.include_router(match_controller.router, tags=["match"])

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -43,7 +43,9 @@ app.add_middleware(
 
 app.include_router(router=auth_router, prefix=settings.API_V1_STR)
 app.include_router(router=webrtc_router, prefix=settings.API_V1_STR)
-app.include_router(router=match_router, prefix=settings.API_V1_STR)
+# WebSocket endpoints for matchmaking should be accessible without the
+# standard API prefix so clients can connect to "/ws/match/{user_id}".
+app.include_router(router=match_router)
 app.include_router(router=user_router, prefix=settings.API_V1_STR)
 app.include_router(router=game_router, prefix=settings.API_V1_STR)
 app.include_router(router=ranking_router, prefix=settings.API_V1_STR)


### PR DESCRIPTION
## Summary
- expose matchmaking websocket without `/api/v1` prefix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, TypeError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68673b4e3c94832e993e1ca891f8a758