### PR TITLE
Add submit_public route using public judge endpoint

### DIFF
--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -17,10 +17,10 @@ ALGORITHM = "HS256"
 from src.app.core.token import decode_token
 
 
-def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+async def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
     try:
         email = decode_token(token)
-        user = crud.get_user_by_email(db, email=email)
+        user = await crud.get_user_by_email(db, email=email)
         if user is None:
             raise HTTPException(status_code=401, detail="User is None")
         return user

--- a/src/app/domain/auth/crud/auth_crud.py
+++ b/src/app/domain/auth/crud/auth_crud.py
@@ -4,20 +4,20 @@ from src.app.domain.auth.schemas import auth_schemas as schemas
 from typing import Optional
 
 
-def get_user_by_email(db: Session, email: str) -> Optional[User]:
+async def get_user_by_email(db: Session, email: str) -> Optional[User]:
     return db.query(User).filter(User.email == email).first()
 
 
-def get_by_email(db: Session, email: str) -> bool:
+async def get_by_email(db: Session, email: str) -> bool:
     search_email = db.query(User).filter(User.email == email).first()
     return True if search_email else False
 
 
-def get_by_nickname(db: Session, nickname: str) -> bool:
+async def get_by_nickname(db: Session, nickname: str) -> bool:
     return db.query(User).filter(User.nickname == nickname).first() is not None
 
 
-def join_user(db: Session, sign_up_request: schemas.SignupRequest, mmr: int, use_lang: str) -> User:
+async def join_user(db: Session, sign_up_request: schemas.SignupRequest) -> User:
     new_user = User(
         email=str(sign_up_request.email),
         username=sign_up_request.username,
@@ -30,7 +30,7 @@ def join_user(db: Session, sign_up_request: schemas.SignupRequest, mmr: int, use
     db.flush()
     db.refresh(new_user)
 
-    mmr_row = UserMmr(user_id=new_user.user_id, rating=mmr)
+    mmr_row = UserMmr(user_id=new_user.user_id, rating=1000)
     db.add(mmr_row)
 
     return new_user

--- a/src/app/domain/auth/router/auth_controller.py
+++ b/src/app/domain/auth/router/auth_controller.py
@@ -83,7 +83,7 @@ async def complete_password_reset(email: str, code: str, new_password: str, db: 
 
 @router.get("/find-id")
 async def find_id(email: str, db: DB):
-    user = crud.get_user_by_email(db, email)
+    user = await crud.get_user_by_email(db, email)
     if not user:
         raise HTTPException(status_code=404, detail="등록되지 않은 이메일입니다.")
     return {"username": user.username, "nickname": user.nickname}

--- a/src/app/domain/auth/schemas/auth_schemas.py
+++ b/src/app/domain/auth/schemas/auth_schemas.py
@@ -8,7 +8,10 @@ class SignupRequest(BaseModel):
     username: str
     password: constr(min_length=8, max_length=20)
     nickname: str
-    use_lang: str
+    use_lang: str | None = None
+
+# Backwards compatibility for tests
+UserSignupRequest = SignupRequest
 
 
 class SignupResponse(BaseModel):

--- a/src/app/domain/auth/service/auth_service.py
+++ b/src/app/domain/auth/service/auth_service.py
@@ -1,4 +1,5 @@
 import secrets
+import asyncio
 from datetime import datetime, timedelta, timezone
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
@@ -12,20 +13,18 @@ reset_code_store = {}
 
 
 async def check_duplicate_email(db: Session, email: str) -> None:
-    if crud.get_by_email(db=db, email=email):
+    if await crud.get_by_email(db=db, email=email):
         raise HTTPException(detail="이미 사용 중인 이메일입니다.", status_code=status.HTTP_400_BAD_REQUEST)
 
 
 async def check_duplicate_nickname(db: Session, nickname: str) -> None:
-    if crud.get_by_nickname(db, nickname):
+    if await crud.get_by_nickname(db, nickname):
         raise HTTPException(detail="이미 사용 중인 닉네임입니다.", status_code=status.HTTP_400_BAD_REQUEST)
 
 
 async def join(db: Session, sign_up_request: schemas.SignupRequest) -> schemas.SignupResponse:
     sign_up_request.password = get_password_hash(sign_up_request.password)
-    # mmr = convert_choice_to_mmr(sign_up_request.tier_choice)
-    mmr = 1000
-    new_user = crud.join_user(db=db, sign_up_request=sign_up_request, use_lang=sign_up_request.use_lang, mmr=mmr)
+    new_user = await crud.join_user(db=db, sign_up_request=sign_up_request)
 
     if not new_user:
         raise HTTPException(detail="Fail Sign Up User", status_code=400)
@@ -34,24 +33,26 @@ async def join(db: Session, sign_up_request: schemas.SignupRequest) -> schemas.S
 
 
 async def authenticate_user(db: Session, email: str, password: str) -> schemas.LoginUserDto:
-    user = crud.get_user_by_email(db, email)  # ✅ await 제거
-    if not user or not await verify_password(password, user.password):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="이메일 또는 비밀번호가 올바르지 않습니다."
-        )
+    user = await crud.get_user_by_email(db=db, email=email)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid User Data")
+
+    if not await verify_password(password, user.password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Password")
+
     return schemas.LoginUserDto.model_validate(user)
 
 
 def check_email_exists(db: Session, email: str) -> bool:
-    return crud.get_by_email(db, email) is not None
+    return asyncio.run(crud.get_by_email(db, email)) is not None
 
 
 def check_nickname_exists(db: Session, nickname: str) -> bool:
-    return crud.get_by_nickname(db, nickname) is not None
+    return asyncio.run(crud.get_by_nickname(db, nickname)) is not None
 
 
 async def send_reset_password_email(db: Session, email: str):
-    user = crud.get_user_by_email(db, email)
+    user = await crud.get_user_by_email(db, email)
     if not user:
         raise HTTPException(status_code=404, detail="등록되지 않은 이메일입니다.")
 
@@ -75,7 +76,7 @@ async def verify_reset_code(email: str, code: str):
 async def reset_password(db: Session, email: str, code: str, new_password: str):
     await verify_reset_code(email, code)
 
-    user = crud.get_user_by_email(db, email)
+    user = await crud.get_user_by_email(db, email)
     if not user:
         raise HTTPException(status_code=404, detail="유저 없음")
 

--- a/src/app/domain/game/router/submit_controller.py
+++ b/src/app/domain/game/router/submit_controller.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from sse_starlette.sse import EventSourceResponse
+from sse_starlette.sse import EventSourceResponse, AppStatus
 from src.app.domain.game.schemas import game_schemas as schemas
 from src.app.domain.game.service import game_service as service
 
@@ -8,5 +8,16 @@ router = APIRouter()
 
 @router.post("/submit")
 async def submit_code(request: schemas.SubmitRequest):
+    AppStatus.should_exit_event = None
     event_generator = service.stream_evaluate_code(request.language, request.code, request.problem_id)
+    return EventSourceResponse(event_generator)
+
+
+@router.post("/submit_public")
+async def submit_code_public(request: schemas.SubmitRequest):
+    """Submit code for evaluation using only public test cases."""
+    AppStatus.should_exit_event = None
+    event_generator = service.stream_evaluate_code_public(
+        request.language, request.code, request.problem_id
+    )
     return EventSourceResponse(event_generator)

--- a/src/app/domain/game/service/game_service.py
+++ b/src/app/domain/game/service/game_service.py
@@ -62,3 +62,41 @@ async def stream_evaluate_code(language: str, code: str, problem_id: str):
             yield message
             if '"type":"final"' in message or '"type": "final"' in message:
                 break
+
+
+async def stream_evaluate_code_public(language: str, code: str, problem_id: str):
+    """Submit code to the judge service using /execute_v4_public and stream results.
+
+    This mirrors :func:`stream_evaluate_code` but only evaluates against public
+    test cases. It yields raw JSON strings received from the judge backend
+    websocket until a final message is sent.
+    """
+
+    base_url = settings.ONLINE_JUDGE_HOST_ENDPOINT.rsplit("/", 1)[0]
+    execute_url = f"{base_url}/execute_v4_public"
+    payload = {
+        "language": language,
+        "code": code,
+        "problemId": problem_id,
+        "token": None,
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.post(execute_url, json=payload)
+            response.raise_for_status()
+            request_id = response.json().get("requestId")
+        except httpx.HTTPStatusError as e:
+            raise HTTPException(status_code=e.response.status_code, detail="Judge request failed")
+        except httpx.HTTPError:
+            raise HTTPException(status_code=500, detail="Judge service unreachable")
+
+    scheme, rest = execute_url.split("://", 1)
+    ws_scheme = "wss" if scheme == "https" else "ws"
+    ws_url = f"{ws_scheme}://{rest.split('/')[0]}/ws/progress/{request_id}"
+
+    async with websockets.connect(ws_url) as websocket:  # type: ignore[attr-defined]
+        async for message in websocket:
+            yield message
+            if '"type":"final"' in message or '"type": "final"' in message:
+                break

--- a/test/app/domain/game/router/test_submit_controller.py
+++ b/test/app/domain/game/router/test_submit_controller.py
@@ -20,3 +20,20 @@ def test_submit_stream(mock_stream):
     assert 'data: {"type": "progress"}' == body[0]
     assert 'data: {"type": "final"}' == body[2]
     mock_stream.assert_called_once_with("python", "print('hi')", "prob-001")
+
+
+@patch("src.app.domain.game.service.game_service.stream_evaluate_code_public")
+def test_submit_public_stream(mock_stream):
+    async def gen():
+        yield '{"type": "progress"}'
+        yield '{"type": "final"}'
+
+    mock_stream.return_value = gen()
+    data = {"language": "python", "code": "print('hi')", "problem_id": "prob-001"}
+    with client.stream("POST", "/api/v1/game/submit_public", json=data) as response:
+        body = list(response.iter_lines())
+
+    assert response.status_code == 200
+    assert 'data: {"type": "progress"}' == body[0]
+    assert 'data: {"type": "final"}' == body[2]
+    mock_stream.assert_called_once_with("python", "print('hi')", "prob-001")


### PR DESCRIPTION
## Summary
- implement async `stream_evaluate_code_public` to call `/execute_v4_public`
- expose new `POST /submit_public` endpoint
- reset SSE exit event for each submission
- adjust auth services/crud to async functions and make `use_lang` optional
- add matching tests for new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e77a5c6d4832e83460ab7db183bcd