### PR TITLE
Add user withdrawal endpoint

### DIFF
--- a/src/app/domain/user/crud/user_crud.py
+++ b/src/app/domain/user/crud/user_crud.py
@@ -1,5 +1,12 @@
 from sqlalchemy.orm import Session
-from src.app.models.models import User, UserMmr
+from src.app.models.models import (
+    User,
+    UserMmr,
+    MatchLog,
+    Ranking,
+    RankChangeLog,
+    CheatReport,
+)
 from typing import Optional
 
 
@@ -25,7 +32,23 @@ def delete_user(db: Session, user_id: int) -> bool:
     if not user:
         return False
 
-    db.query(UserMmr).filter(UserMmr.user_id == user_id).delete()
+    # nullify related records referencing this user instead of deleting them
+    db.query(MatchLog).filter(MatchLog.user_id == user_id).update(
+        {MatchLog.user_id: None}, synchronize_session=False
+    )
+    db.query(Ranking).filter(Ranking.user_id == user_id).update(
+        {Ranking.user_id: None}, synchronize_session=False
+    )
+    db.query(RankChangeLog).filter(RankChangeLog.user_id == user_id).update(
+        {RankChangeLog.user_id: None}, synchronize_session=False
+    )
+    db.query(CheatReport).filter(CheatReport.reported_user_id == user_id).update(
+        {CheatReport.reported_user_id: None}, synchronize_session=False
+    )
+    db.query(UserMmr).filter(UserMmr.user_id == user_id).update(
+        {UserMmr.user_id: None}, synchronize_session=False
+    )
+
     db.delete(user)
     db.commit()
     return True

--- a/src/app/domain/user/crud/user_crud.py
+++ b/src/app/domain/user/crud/user_crud.py
@@ -19,6 +19,18 @@ def update_user(db: Session, user: User):
     return user
 
 
+def delete_user(db: Session, user_id: int) -> bool:
+    """Delete user and related MMR information."""
+    user = db.query(User).filter(User.user_id == user_id).first()
+    if not user:
+        return False
+
+    db.query(UserMmr).filter(UserMmr.user_id == user_id).delete()
+    db.delete(user)
+    db.commit()
+    return True
+
+
 def get_user_mmr(db: Session, user_id: int) -> int:
     mmr_obj = db.query(UserMmr).filter(UserMmr.user_id == user_id).first()
     return mmr_obj.rating if mmr_obj else 1000

--- a/src/app/domain/user/router/user_controller.py
+++ b/src/app/domain/user/router/user_controller.py
@@ -85,3 +85,16 @@ async def update_my_profile_handler(
         message="회원 정보가 성공적으로 수정되었습니다.",
         user=schemas.UserResponseDto(**user_dict),
     )
+
+
+@router.delete("/me")
+async def delete_my_account(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """회원 탈퇴 처리."""
+    logger.info(f"Deleting account for user ID: {current_user.user_id}")
+    success = await service.delete_my_account(db, current_user.user_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"message": "회원 탈퇴가 완료되었습니다."}

--- a/src/app/domain/user/service/user_service.py
+++ b/src/app/domain/user/service/user_service.py
@@ -61,3 +61,13 @@ async def update_my_profile(
     crud.update_user(db, user)
     logger.info(f"Profile update complete for user ID: {user_id}")
     return user
+
+
+async def delete_my_account(db: Session, user_id: int) -> bool:
+    """Delete the user account."""
+    logger.info(f"Attempting to delete account for user ID: {user_id}")
+    try:
+        return crud.delete_user(db, user_id)
+    except Exception as e:
+        logger.error(f"Failed to delete user {user_id}: {e}")
+        raise

--- a/test/app/domain/user/router/test_user_controller.py
+++ b/test/app/domain/user/router/test_user_controller.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from src.app.main import app
+from src.app.core.database import get_db
+from src.app.core.security import get_current_user
+
+app.dependency_overrides[get_db] = lambda: MagicMock()
+app.dependency_overrides[get_current_user] = lambda: MagicMock(user_id=1)
+client = TestClient(app)
+
+@patch("src.app.domain.user.service.user_service.delete_my_account", return_value=True)
+def test_delete_my_account_success(mock_delete):
+    response = client.delete("/api/v1/user/me")
+    assert response.status_code == 200
+    assert response.json() == {"message": "회원 탈퇴가 완료되었습니다."}
+    mock_delete.assert_called_once()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,15 @@
+import os
+
+# Ensure database URL components exist for module imports
+os.environ.setdefault('DB_HOST', 'localhost')
+os.environ.setdefault('DB_PORT', '5432')
+os.environ.setdefault('DB_USER', 'user')
+os.environ.setdefault('DB_PASSWORD', 'pass')
+os.environ.setdefault('DB_NAME', 'testdb')
+os.environ.setdefault('SECRET_KEY', 'secret')
+os.environ.setdefault('SECRET_KEY_AUTH', 'secret')
+os.environ.setdefault('AWS_REGION', 'us-east-1')
+os.environ.setdefault('PROBLEM_BUCKET', 'test-bucket')
+os.environ.setdefault('REPORT_BUCKET', 'test-bucket')
+os.environ.setdefault('PROFILE_IMAGE_BUCKET', 'test-bucket')
+


### PR DESCRIPTION
## Summary
- support deleting a user account via `/user/me`
- implement user removal in service and CRUD layers
- add a test for the new endpoint

## Testing
- `pytest -q` *(fails: ImportError and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_6873d09f8a6c832ea76f70be1e5fda63